### PR TITLE
use caching interceptor flag

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -37,3 +37,4 @@ rateLimiterSecret:
 keepAliveTimeout:
   downstream: 61000
   upstream: 60000
+useCachingInterceptor: false

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -37,3 +37,5 @@ rateLimiterSecret:
 keepAliveTimeout:
   downstream: 61000
   upstream: 60000
+useCachingInterceptor: false
+

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -37,3 +37,5 @@ rateLimiterSecret:
 keepAliveTimeout:
   downstream: 61000
   upstream: 60000
+useCachingInterceptor: false
+

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -233,4 +233,5 @@ export class ApiConfigService {
   getUseCachingInterceptor(): boolean {
     return this.configService.get<boolean>('useCachingInterceptor') ?? false;
   }
+
 }

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -229,4 +229,8 @@ export class ApiConfigService {
   getHeadersTimeout(): number {
     return this.getServerTimeout() + 1000;
   }
+
+  getUseCachingInterceptor(): boolean {
+    return this.configService.get<boolean>('useCachingInterceptor') ?? false;
+  }
 }


### PR DESCRIPTION
## Type

- [ ] Bug
- [x] Feature
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting

- Caching interceptor is activated by default in microservices
- No configuration present in order to disable it

## Proposed Changes

- Add a config flag in order to enable/disable CachingInterceptor
- Set useCachingInterceptor to false by default

## How to test

- Enable caching interceptor, chef if data is retrieved from cache
